### PR TITLE
Specified Node JS version in .travis.yml to fix a Travis deployment error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 
+node_js:
+    - "7"
+
 script:
     - npm install -g jsforce-metadata-tools
     - jsforce-deploy --dry-run -u $DEPLOYMENT_USERNAME -p $DEPLOYMENT_PASSWORD$DEPLOYMENT_TOKEN -D $TRAVIS_BUILD_DIR/src -l $DEPLOYMENT_LOGIN_URL --rollbackOnError true --testLevel $DEPLOYMENT_TEST_LEVEL --pollTimeout $POLL_TIMEOUT


### PR DESCRIPTION
JSForce has started showing the below error due to Travis using an older version of Node JS - .travis.yml has been updated to solve this by specifying version 7 of node

```
/home/travis/.nvm/v0.10.48/lib/node_modules/jsforce-metadata-tools/node_modules/decompress/index.js:2
const path = require('path');
^^^^^
SyntaxError: Use of const in strict mode.
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/travis/.nvm/v0.10.48/lib/node_modules/jsforce-metadata-tools/lib/retrieve.js:3:18)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
```