### PR TITLE
Fixed QueryFilter collections bug

### DIFF
--- a/src/classes/CollectionUtils.cls
+++ b/src/classes/CollectionUtils.cls
@@ -9,6 +9,7 @@ public without sharing class CollectionUtils {
     }
 
     public static Boolean isList(Object input) {
+        // If we can cast the object to a list of objects, then it's a list
         try {
            Object convertedInput = (List<Object>)input;
            return true;
@@ -18,6 +19,9 @@ public without sharing class CollectionUtils {
     }
 
     public static Boolean isSet(Object input) {
+        // We can't cast the object to a set of objects
+        // But if we try to cast it to a list of objects & it's a set,
+        // then a TypeException is thrown so we know it's a set
         try {
            Object convertedInput = (List<Object>)input;
            return false;
@@ -27,6 +31,9 @@ public without sharing class CollectionUtils {
     }
 
     public static Boolean isMap(Object input) {
+        // We can't cast the object to a map of objects
+        // But if we try to cast it to a list of objects & it's a map,
+        // then a TypeException is thrown so we know it's a map
         try {
            Object convertedInput = (List<Object>)input;
            return false;

--- a/src/classes/CollectionUtils.cls
+++ b/src/classes/CollectionUtils.cls
@@ -1,0 +1,38 @@
+/*************************************************************************************************
+* This file is part of the Nebula Framework project, released under the MIT License.             *
+* See LICENSE file or go to https://github.com/jongpie/NebulaFramework for full license details. *
+*************************************************************************************************/
+public without sharing class CollectionUtils {
+
+    public static Boolean isCollection(Object input) {
+        return isList(input) || isSet(input) || isMap(input);
+    }
+
+    public static Boolean isList(Object input) {
+        try {
+           Object convertedInput = (List<Object>)input;
+           return true;
+        } catch(System.TypeException ex) {
+            return false;
+        }
+    }
+
+    public static Boolean isSet(Object input) {
+        try {
+           Object convertedInput = (List<Object>)input;
+           return false;
+        } catch(System.TypeException ex) {
+            return ex.getMessage().contains('Set<');
+        }
+    }
+
+    public static Boolean isMap(Object input) {
+        try {
+           Object convertedInput = (List<Object>)input;
+           return false;
+        } catch(System.TypeException ex) {
+            return ex.getMessage().contains('Map<');
+        }
+    }
+
+}

--- a/src/classes/CollectionUtils.cls-meta.xml
+++ b/src/classes/CollectionUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CollectionUtils_Tests.cls
+++ b/src/classes/CollectionUtils_Tests.cls
@@ -5,42 +5,131 @@
 @isTest
 private class CollectionUtils_Tests {
 
+    // Tests for lists
     @isTest
-    static void it_should_say_that_a_list_is_a_list_and_a_collection() {
+    static void it_should_say_that_a_list_of_strings_is_a_list_and_a_collection() {
+        List<String> collectionToCheck = new List<String>{'A', 'B', 'C'};
+
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_a_list_of_integers_is_a_list_and_a_collection() {
         List<Integer> collectionToCheck = new List<Integer>{1, 2, 3};
 
         System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
         System.assertEquals(true, CollectionUtils.isList(collectionToCheck));
-
         System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
         System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
     }
 
     @isTest
-    static void it_should_say_that_a_set_is_a_set_and_a_collection() {
+    static void it_should_say_that_a_list_of_users_is_a_list_and_a_collection() {
+        List<User> collectionToCheck = [SELECT Id FROM User LIMIT 10];
+
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
+    }
+
+    // Tests for sets
+    @isTest
+    static void it_should_say_that_a_set_of_strings_is_a_set_and_a_collection() {
         Set<String> collectionToCheck = new Set<String>{'A', 'B', 'C'};
 
         System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
         System.assertEquals(true, CollectionUtils.isSet(collectionToCheck));
-
         System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
         System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
     }
 
     @isTest
-    static void it_should_say_that_a_map_is_a_map_and_a_collection() {
-        Map<Id, User> collectionToCheck = new Map<Id, User>([SELECT Id FROM User]);
+    static void it_should_say_that_a_set_of_integers_is_a_set_and_a_collection() {
+        Set<Integer> collectionToCheck = new Set<Integer>{1, 2, 3};
+
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isSet(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_a_set_of_users_is_a_set_and_a_collection() {
+        Set<User> collectionToCheck = new Set<User>([SELECT Id FROM User LIMIT 10]);
+
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isSet(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
+    }
+
+    // Tests for maps
+    @isTest
+    static void it_should_say_that_a_map_of_strings_is_a_map_and_a_collection() {
+        Map<String, Integer> collectionToCheck = new Map<String, Integer>{
+            'First'  => 1,
+            'Second' => 2,
+            'Third'  => 3
+        };
 
         System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
         System.assertEquals(true, CollectionUtils.isMap(collectionToCheck));
-
         System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
         System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
     }
 
     @isTest
+    static void it_should_say_that_a_map_of_integers_is_a_map_and_a_collection() {
+        Map<Integer, String> collectionToCheck = new Map<Integer, String>{
+             1 => 'First',
+             2 => 'Second',
+             3 => 'Third'
+        };
+
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isMap(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_a_map_of_users_is_a_map_and_a_collection() {
+        Map<Id, User> collectionToCheck = new Map<Id, User>([SELECT Id FROM User LIMIT 10]);
+
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isMap(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
+    }
+
+    // Negative tests
+    @isTest
     static void it_should_say_that_a_string_is_not_collection() {
         String valueToCheck = 'test string';
+
+        System.assertEquals(false, CollectionUtils.isCollection(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isList(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(valueToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_an_integer_is_not_collection() {
+        Integer valueToCheck = 1;
+
+        System.assertEquals(false, CollectionUtils.isCollection(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isList(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(valueToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_a_user_is_not_collection() {
+        User valueToCheck = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
 
         System.assertEquals(false, CollectionUtils.isCollection(valueToCheck));
         System.assertEquals(false, CollectionUtils.isList(valueToCheck));

--- a/src/classes/CollectionUtils_Tests.cls
+++ b/src/classes/CollectionUtils_Tests.cls
@@ -1,0 +1,51 @@
+/*************************************************************************************************
+* This file is part of the Nebula Framework project, released under the MIT License.             *
+* See LICENSE file or go to https://github.com/jongpie/NebulaFramework for full license details. *
+*************************************************************************************************/
+@isTest
+private class CollectionUtils_Tests {
+
+    @isTest
+    static void it_should_say_that_a_list_is_a_list_and_a_collection() {
+        List<Integer> collectionToCheck = new List<Integer>{1, 2, 3};
+
+        System.assertEquals(true,CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true,CollectionUtils.isList(collectionToCheck));
+
+        System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_a_set_is_a_set_and_a_collection() {
+        Set<String> collectionToCheck = new Set<String>{'A', 'B', 'C'};
+
+        System.assertEquals(true,CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true,CollectionUtils.isSet(collectionToCheck));
+
+        System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_a_map_is_a_map_and_a_collection() {
+        Map<Id, User> collectionToCheck = new Map<Id, User>([SELECT Id FROM User]);
+
+        System.assertEquals(true,CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true,CollectionUtils.isMap(collectionToCheck));
+
+        System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
+    }
+
+    @isTest
+    static void it_should_say_that_a_string_is_not_collection() {
+        String valueToCheck = 'test string';
+
+        System.assertEquals(false, CollectionUtils.isCollection(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isList(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isSet(valueToCheck));
+        System.assertEquals(false, CollectionUtils.isMap(valueToCheck));
+    }
+
+}

--- a/src/classes/CollectionUtils_Tests.cls
+++ b/src/classes/CollectionUtils_Tests.cls
@@ -9,8 +9,8 @@ private class CollectionUtils_Tests {
     static void it_should_say_that_a_list_is_a_list_and_a_collection() {
         List<Integer> collectionToCheck = new List<Integer>{1, 2, 3};
 
-        System.assertEquals(true,CollectionUtils.isCollection(collectionToCheck));
-        System.assertEquals(true,CollectionUtils.isList(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isList(collectionToCheck));
 
         System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));
         System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
@@ -20,8 +20,8 @@ private class CollectionUtils_Tests {
     static void it_should_say_that_a_set_is_a_set_and_a_collection() {
         Set<String> collectionToCheck = new Set<String>{'A', 'B', 'C'};
 
-        System.assertEquals(true,CollectionUtils.isCollection(collectionToCheck));
-        System.assertEquals(true,CollectionUtils.isSet(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isSet(collectionToCheck));
 
         System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
         System.assertEquals(false, CollectionUtils.isMap(collectionToCheck));
@@ -31,8 +31,8 @@ private class CollectionUtils_Tests {
     static void it_should_say_that_a_map_is_a_map_and_a_collection() {
         Map<Id, User> collectionToCheck = new Map<Id, User>([SELECT Id FROM User]);
 
-        System.assertEquals(true,CollectionUtils.isCollection(collectionToCheck));
-        System.assertEquals(true,CollectionUtils.isMap(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isCollection(collectionToCheck));
+        System.assertEquals(true, CollectionUtils.isMap(collectionToCheck));
 
         System.assertEquals(false, CollectionUtils.isList(collectionToCheck));
         System.assertEquals(false, CollectionUtils.isSet(collectionToCheck));

--- a/src/classes/CollectionUtils_Tests.cls-meta.xml
+++ b/src/classes/CollectionUtils_Tests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/QueryArgumentFormatter.cls
+++ b/src/classes/QueryArgumentFormatter.cls
@@ -18,7 +18,9 @@ public virtual class QueryArgumentFormatter extends NebulaCore implements IQuery
 
     protected virtual String objectToQueryString(Object valueToFormat) {
         if(valueToFormat == null) return null;
-        else if(valueToFormat instanceof List<Object>) return this.listToQueryString((List<Object>)valueToFormat);
+        else if(CollectionUtils.isList(valueToFormat)) return this.listToQueryString((List<Object>)valueToFormat);
+        else if(CollectionUtils.isSet(valueToFormat)) return this.setToQueryString(valueToFormat);
+        else if(CollectionUtils.isMap(valueToFormat)) return this.mapToQueryString(valueToFormat);
         else if(valueToFormat instanceof QueryDateLiteral) {
             QueryDateLiteral dateLiteral = (QueryDateLiteral)valueToFormat;
             return dateLiteral.getValue();
@@ -45,13 +47,31 @@ public virtual class QueryArgumentFormatter extends NebulaCore implements IQuery
         else return String.valueOf(valueToFormat);
     }
 
-    protected virtual String listToQueryString(List<Object> valueList) {
+    private String listToQueryString(List<Object> valueList) {
         List<String> parsedValueList = new List<String>();
         for(Object value : valueList) parsedValueList.add(this.objectToQueryString(value));
-        return '(' + String.join(parsedValueList, ',') + ')';
+        return '(' + String.join(parsedValueList, ', ') + ')';
     }
 
-    protected virtual String wrapInSingleQuotes(String input) {
+    private String setToQueryString(Object valueSet) {
+        String unformattedString = String.valueOf(valueSet).replace('{', '').replace('}', '');
+        List<String> parsedValueList = new List<String>();
+        for(String collectionItem : unformattedString.split(',')) {
+            parsedValueList.add(this.objectToQueryString(collectionItem));
+        }
+
+        return '(' + String.join(parsedValueList, ', ') + ')';
+    }
+
+    private String mapToQueryString(Object valueMap) {
+        Map<String, Object> m = (Map<String, Object>)JSON.deserializeUntyped(JSON.serialize(valueMap));
+
+        return this.setToQueryString(m.keySet());
+    }
+
+    private String wrapInSingleQuotes(String input) {
+        input = input.trim();
+
         if(input.left(1) != '\'') input = '\'' + input;
         if(input.right(1) != '\'') input = input + '\'';
         return input;

--- a/src/classes/QueryArgumentFormatter_Tests.cls
+++ b/src/classes/QueryArgumentFormatter_Tests.cls
@@ -20,10 +20,36 @@ private class QueryArgumentFormatter_Tests {
     @isTest
     static void it_should_return_query_string_for_list() {
         List<Integer> providedValueList  = new List<Integer>{1, 2, 3};
-        String expectedString = '(' + String.join(providedValueList, ',') + ')';
+        String expectedString = '(1, 2, 3)';
 
         Test.startTest();
         String returnedValue = new QueryArgumentFormatter(providedValueList).getValue();
+        Test.stopTest();
+
+        System.assertEquals(expectedString, returnedValue);
+    }
+
+    @isTest
+    static void it_should_return_query_string_for_set() {
+        Set<String> providedValueSet = new Set<String>{'A', 'B', 'C'};
+        String expectedString = '(\'A\', \'B\', \'C\')';
+
+        Test.startTest();
+        String returnedValue = new QueryArgumentFormatter(providedValueSet).getValue();
+        Test.stopTest();
+
+        System.assertEquals(expectedString, returnedValue);
+    }
+
+    @isTest
+    static void it_should_return_query_string_for_map() {
+        Map<Id, User> providedValueMap = new Map<Id, User>([SELECT Id FROM User LIMIT 10]);
+        List<Id> sortedIdList = new List<Id>(providedValueMap.keySet());
+        sortedIdList.sort();
+        String expectedString = '(\'' + String.join(sortedIdList, '\', \'') + '\')';
+
+        Test.startTest();
+        String returnedValue = new QueryArgumentFormatter(providedValueMap).getValue();
         Test.stopTest();
 
         System.assertEquals(expectedString, returnedValue);


### PR DESCRIPTION
Fixes #54 
* QueryArgumentFormatter.cls relies on 'instanceof' to determine how to convert the object to a string (for use in dynamic SOQL/SOSL). 'instanceof' doesn't work for determining if the object is a set or map
* (Re)created CollectionUtils.cls with some hacky methods to determine if the object is a list, set or map
* QueryArgumentFormatter.cls now uses CollectionUtils.cls to determine if the object is a collection & then converts it to a string