### PR TITLE
Sobject field wrapper

### DIFF
--- a/src/classes/IQueryFilter.cls
+++ b/src/classes/IQueryFilter.cls
@@ -14,7 +14,7 @@ public interface IQueryFilter {
 
     // Setter methods
     IQueryFilter filterByField(Schema.SObjectField fieldToFilter, QueryOperator operator, Object providedValue);
-    IQueryFilter filterByParentField(List<Schema.SObjectField> fieldToFilterChain, QueryOperator operator, Object providedValue);
+    IQueryFilter filterByParentField(SObjectFieldWrapper fieldWrapper, QueryOperator operator, Object providedValue);
     IQueryFilter filterByQueryDate(QueryDate queryDateToFilter, QueryOperator operator, Integer providedValue);
     IQueryFilter filterBySubquery(QueryOperator inOrNotIn, Schema.SObjectField lookupFieldOnRelatedSObject);
     IQueryFilter filterBySubquery(QueryOperator inOrNotIn, Schema.SObjectField lookupField, Schema.SObjectField lookupFieldOnRelatedSObject);

--- a/src/classes/QueryFilter.cls
+++ b/src/classes/QueryFilter.cls
@@ -26,7 +26,7 @@ public class QueryFilter implements IQueryFilter {
     * System.assertEquals('Email != null', filter.getValue());
     */
     public IQueryFilter filterByField(Schema.SObjectField fieldToFilter, QueryOperator operator, Object providedValue) {
-        return this.filterByParentField(new List<Schema.SObjectField>{fieldToFilter}, operator, providedValue);
+        return this.filterByParentField(new SObjectFieldWrapper(fieldToFilter), operator, providedValue);
     }
 
     /**
@@ -40,8 +40,8 @@ public class QueryFilter implements IQueryFilter {
     * QueryFilter filter = new QueryFilter().setValue(parentFieldChain, QueryOperator.NOT_EQUAL_TO, null);
     * System.assertEquals('CreatedBy.Email != null', filter.getValue());
     */
-    public IQueryFilter filterByParentField(List<Schema.SObjectField> fieldToFilterChain, QueryOperator operator, Object providedValue) {
-        this.queryFilterString = this.parseSObjectFieldName(fieldToFilterChain)
+    public IQueryFilter filterByParentField(SObjectFieldWrapper fieldWrapper, QueryOperator operator, Object providedValue) {
+        this.queryFilterString = fieldWrapper.VALUE
             + ' ' + operator.getValue()
             + ' ' + NebulaFactory.getQueryArgumentFormatter().getValue(providedValue);
 
@@ -119,24 +119,6 @@ public class QueryFilter implements IQueryFilter {
     */
     public String getValue() {
         return this.queryFilterString;
-    }
-
-    private String parseSObjectFieldName(List<Schema.SObjectField> fieldToFilterChain) {
-        Schema.SObjectField lastField = (Schema.SObjectField)CollectionUtils.pop(fieldToFilterChain);
-
-        List<String> fieldChain = new List<String>();
-        for(Schema.SObjectField parentField : fieldToFilterChain) {
-            fieldChain.add(parentField.getDescribe().getRelationshipName());
-        }
-
-        String parsedFieldChain = '';
-        if(!fieldChain.isEmpty()) {
-            // If there is a chain of fields, build a string with the dot notation needed for SOQL/SOSL
-            parsedFieldChain = String.join(fieldChain, '.') + '.';
-        }
-
-        // Return the fully qualified field name
-        return parsedFieldChain + lastField.getDescribe().getName();
     }
 
     private IQueryFilter setValueForSubquery(String idFieldName, QueryOperator inOrNotIn, Schema.SObjectField lookupFieldOnRelatedSObject) {

--- a/src/classes/QueryFilter.cls
+++ b/src/classes/QueryFilter.cls
@@ -41,7 +41,7 @@ public class QueryFilter implements IQueryFilter {
     * System.assertEquals('CreatedBy.Email != null', filter.getValue());
     */
     public IQueryFilter filterByParentField(SObjectFieldWrapper fieldWrapper, QueryOperator operator, Object providedValue) {
-        this.queryFilterString = fieldWrapper.VALUE
+        this.queryFilterString = fieldWrapper.Value
             + ' ' + operator.getValue()
             + ' ' + NebulaFactory.getQueryArgumentFormatter().getValue(providedValue);
 

--- a/src/classes/QueryFilter_Tests.cls
+++ b/src/classes/QueryFilter_Tests.cls
@@ -21,9 +21,9 @@ private class QueryFilter_Tests {
 
     @isTest
     static void it_should_return_the_query_filter_for_a_parent_field() {
-         List<Schema.SObjectField> parentFieldToFilter = new List<Schema.SObjectField>{
+         SObjectFieldWrapper parentFieldToFilter = new SObjectFieldWrapper(new List<Schema.SObjectField>{
             Schema.Lead.CreatedById, Schema.User.Email
-        };
+        });
         QueryOperator operator = QueryOperator.EQUALS;
         String providedValue   = 'derp@test.com';
 
@@ -37,9 +37,9 @@ private class QueryFilter_Tests {
 
     @isTest
     static void it_should_return_the_query_filter_for_a_grandparent_field() {
-        List<Schema.SObjectField> grandparentFieldToFilter = new List<Schema.SObjectField>{
+        SObjectFieldWrapper grandparentFieldToFilter = new SObjectFieldWrapper(new List<Schema.SObjectField>{
             Schema.Lead.OwnerId, Schema.User.ManagerId, Schema.User.ProfileId, Schema.Profile.Name
-        };
+        });
         QueryOperator operator = QueryOperator.EQUALS;
         String providedValue   = 'derp';
 

--- a/src/classes/SObjectFieldWrapper.cls
+++ b/src/classes/SObjectFieldWrapper.cls
@@ -1,0 +1,29 @@
+public class SObjectFieldWrapper {
+    private final List<SObjectField> fields;
+
+    public SObjectFieldWrapper(SObjectField field) {
+        this(new List<SObjectField>{ field });
+    }
+
+    public SObjectFieldWrapper(List<SObjectField> fields) {
+        this.fields = fields;
+    }
+
+    public String VALUE {
+        get {
+            if(this.Fields.size() == 1 ) {
+                return String.valueOf(this.Fields[0]);
+            }
+
+            //Remove the last field from the list to iterate through so only the parent relationships are hopped
+            List<SObjectField> fieldsToIterate = this.fields.clone();
+            SObjectField lastField = (SObjectField) CollectionUtils.pop(fieldsToIterate);
+            List<String> fieldChain = new List<String>();
+            for(SObjectField parentField : fieldsToIterate) {
+                fieldChain.add(parentField.getDescribe().getRelationshipName());
+            }
+            // Return the fully qualified field name
+            return String.join(fieldChain, '.') + '.' + lastField.getDescribe().getName();
+        }
+    }
+}

--- a/src/classes/SObjectFieldWrapper.cls
+++ b/src/classes/SObjectFieldWrapper.cls
@@ -9,7 +9,7 @@ public class SObjectFieldWrapper {
         this.fields = fields;
     }
 
-    public String VALUE {
+    public String Value {
         get {
             if(this.Fields.size() == 1 ) {
                 return String.valueOf(this.Fields[0]);

--- a/src/classes/SObjectFieldWrapper.cls-meta.xml
+++ b/src/classes/SObjectFieldWrapper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SObjectFieldWrapper.cls-meta.xml
+++ b/src/classes/SObjectFieldWrapper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>38.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/SObjectFieldWrapper_Tests.cls
+++ b/src/classes/SObjectFieldWrapper_Tests.cls
@@ -1,0 +1,22 @@
+@isTest
+private class SObjectFieldWrapper_Tests {
+    @isTest
+    static void it_should_return_string_for_sobject_field_name() {
+        System.assertEquals('CreatedDate', new SObjectFieldWrapper(Lead.CreatedDate).VALUE);
+    }
+
+    @isTest
+    static void it_should_return_string_for_parent_sobject_field_name() {
+        System.assertEquals('Account.Name', new SObjectFieldWrapper(new List<SObjectField>{ Contact.AccountId, Account.Name }).VALUE);
+    }
+
+    @isTest
+    static void it_should_be_callable_multiple_times_without_pop_removing_field_references() {
+        SObjectFieldWrapper wrapper = new SObjectFieldWrapper(new List<SObjectField>{ Contact.AccountId, Account.Name });
+        String expected = 'Account.Name';
+        String actualOne = wrapper.VALUE;
+        String actualTwo = wrapper.VALUE;
+        System.assertEquals(expected, actualOne);
+        System.assertEquals(expected, actualTwo);
+    }
+}

--- a/src/classes/SObjectFieldWrapper_Tests.cls
+++ b/src/classes/SObjectFieldWrapper_Tests.cls
@@ -2,20 +2,20 @@
 private class SObjectFieldWrapper_Tests {
     @isTest
     static void it_should_return_string_for_sobject_field_name() {
-        System.assertEquals('CreatedDate', new SObjectFieldWrapper(Lead.CreatedDate).VALUE);
+        System.assertEquals('CreatedDate', new SObjectFieldWrapper(Lead.CreatedDate).Value);
     }
 
     @isTest
     static void it_should_return_string_for_parent_sobject_field_name() {
-        System.assertEquals('Account.Name', new SObjectFieldWrapper(new List<SObjectField>{ Contact.AccountId, Account.Name }).VALUE);
+        System.assertEquals('Account.Name', new SObjectFieldWrapper(new List<SObjectField>{ Contact.AccountId, Account.Name }).Value);
     }
 
     @isTest
     static void it_should_be_callable_multiple_times_without_pop_removing_field_references() {
         SObjectFieldWrapper wrapper = new SObjectFieldWrapper(new List<SObjectField>{ Contact.AccountId, Account.Name });
         String expected = 'Account.Name';
-        String actualOne = wrapper.VALUE;
-        String actualTwo = wrapper.VALUE;
+        String actualOne = wrapper.Value;
+        String actualTwo = wrapper.Value;
         System.assertEquals(expected, actualOne);
         System.assertEquals(expected, actualTwo);
     }

--- a/src/classes/SObjectFieldWrapper_Tests.cls-meta.xml
+++ b/src/classes/SObjectFieldWrapper_Tests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SObjectFieldWrapper_Tests.cls-meta.xml
+++ b/src/classes/SObjectFieldWrapper_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>38.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
 I also ended up using this, instead of SObjectFields, in the OrderBy interface for IQueryBuilder, because we have production code ordering by parent fields