### PR TITLE
Queries can now be cached with cacheResults()

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,7 +3,8 @@ engines:
         enabled: true
         config:
             rulesets: "./tools/codeclimate/apex/apexunit.xml,./tools/codeclimate/apex/complexity.xml,./tools/codeclimate/apex/performance.xml,./tools/codeclimate/apex/security.xml,./tools/codeclimate/apex/style.xml"
-        enabled: true
+        exclude_paths:
+            - "*_Tests.cls"
 ratings:
     paths:
         - "**.cls"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,7 +4,7 @@ engines:
         config:
             rulesets: "./tools/codeclimate/apex/apexunit.xml,./tools/codeclimate/apex/complexity.xml,./tools/codeclimate/apex/performance.xml,./tools/codeclimate/apex/security.xml,./tools/codeclimate/apex/style.xml"
         exclude_paths:
-            - "*_Tests.cls"
+            - "**Tests.cls"
 ratings:
     paths:
         - "**.cls"

--- a/src/classes/AggregateResultQueryBuilder.cls
+++ b/src/classes/AggregateResultQueryBuilder.cls
@@ -23,6 +23,11 @@ public class AggregateResultQueryBuilder extends QueryBuilder implements IAggreg
         this.groupByList           = new List<String>();
     }
 
+    public IAggregateResultQueryBuilder cacheResults() {
+        super.doCacheResults();
+        return this;
+    }
+
     public IAggregateResultQueryBuilder groupBy(IQueryField groupByQueryField) {
         return this.groupBy(new List<IQueryField>{groupByQueryField});
     }

--- a/src/classes/AggregateResultQueryBuilder_Tests.cls
+++ b/src/classes/AggregateResultQueryBuilder_Tests.cls
@@ -5,6 +5,19 @@
 @isTest
 private class AggregateResultQueryBuilder_Tests {
 
+
+    @isTest
+    static void it_should_be_usable_after_construction() {
+        // Query builders should be usable as soon as it's constructed - it should be able to execute a query with some default values
+        IAggregateResultQueryBuilder aggregateQueryBuilder = new AggregateResultQueryBuilder(Schema.Opportunity.SObjectType);
+
+        Test.startTest();
+
+        List<AggregateResult> results = (List<AggregateResult>)aggregateQueryBuilder.getQueryResults();
+
+        Test.stopTest();
+    }
+
     @isTest
     static void it_should_cache_results() {
         IAggregateResultQueryBuilder aggregateResultQueryBuilder = new AggregateResultQueryBuilder(Schema.Opportunity.SObjectType);

--- a/src/classes/AggregateResultQueryBuilder_Tests.cls
+++ b/src/classes/AggregateResultQueryBuilder_Tests.cls
@@ -6,6 +6,23 @@
 private class AggregateResultQueryBuilder_Tests {
 
     @isTest
+    static void it_should_cache_results() {
+        IAggregateResultQueryBuilder aggregateResultQueryBuilder = new AggregateResultQueryBuilder(Schema.Opportunity.SObjectType);
+        aggregateResultQueryBuilder.cacheResults();
+
+        Test.startTest();
+
+        System.assertEquals(0, Limits.getQueries());
+        for(Integer i = 0; i < 10; i++) {
+            System.debug(aggregateResultQueryBuilder.getQueryResults());
+        }
+
+        System.assertEquals(1, Limits.getQueries());
+
+        Test.stopTest();
+    }
+
+    @isTest
     static void it_should_build_a_ridiculous_query_string() {
         String expectedString = 'SELECT Type,\nAVG(Amount) AVG__Amount, COUNT(AccountId) COUNT__AccountId, '
             + 'COUNT_DISTINCT(OwnerId) COUNT_DISTINCT__OwnerId, MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate'

--- a/src/classes/IAggregateResultQueryBuilder.cls
+++ b/src/classes/IAggregateResultQueryBuilder.cls
@@ -12,6 +12,8 @@
 */
 public interface IAggregateResultQueryBuilder {
 
+    IAggregateResultQueryBuilder cacheResults();
+
     // Group By methods
     IAggregateResultQueryBuilder groupBy(IQueryField groupByQueryField);
     IAggregateResultQueryBuilder groupBy(List<IQueryField> groupByQueryFields);

--- a/src/classes/ISObjectQueryBuilder.cls
+++ b/src/classes/ISObjectQueryBuilder.cls
@@ -12,6 +12,8 @@
 */
 public interface ISObjectQueryBuilder {
 
+    ISObjectQueryBuilder cacheResults();
+
     // Field methods
     ISObjectQueryBuilder addAllFields();
     ISObjectQueryBuilder addAllStandardFields();

--- a/src/classes/ISearchQueryBuilder.cls
+++ b/src/classes/ISearchQueryBuilder.cls
@@ -1,5 +1,7 @@
 public interface ISearchQueryBuilder {
 
+    ISearchQueryBuilder cacheResults();
+
     ISearchQueryBuilder setQuerySearchGroup(QuerySearchGroup searchGroup);
 
     String getQuery();

--- a/src/classes/QueryBuilder.cls
+++ b/src/classes/QueryBuilder.cls
@@ -139,33 +139,6 @@ public abstract class QueryBuilder extends NebulaCore {
         List<List<SObject>> deepClonedResults = new List<List<SObject>>();
         for(List<SObject> cachedListOfResults : cachedResults) deepClonedResults.add(cachedListOfResults.deepClone(true, true, true));
         return deepClonedResults;
-
-        /* Sample code to show cloneing the list of list (doesn't work) vs deep cloning each list withn the list of lists
-        List<List<SObject>> cachedResults = [find 'gillespie' in all fields returning account(id, name)];
-List<List<SObject>> clonedResults = new List<List<SObject>>();
-for(List<SObject> cachedListOfResults : cachedResults) clonedResults.add(cachedListOfResults.deepClone(true, true, true));
-
-System.debug(cachedResults);
-clonedResults[0][0].put('Name', 'Poop');
-clonedResults[0][0].put('Id', null);
-System.debug(clonedResults);
-System.debug(cachedResults);
-System.assertNotEquals(cachedResults[0][0], clonedResults[0][0]);
-insert clonedResults[0][0];
-System.debug(clonedResults);
-System.debug(cachedResults);
-System.assertNotEquals(cachedResults[0][0], clonedResults[0][0]);
-System.assertNotEquals(cachedResults[0][0].Id, clonedResults[0][0].Id);
-///
-
-List<List<Sobject>> rs = [find 'gillespie' in all fields returning account(id, name)];
-System.debug(rs);
-List<List<Sobject>> rsClone = rs.clone();
-rsClone[0][0].put('Name', 'Poop');
-System.debug(rsClone);
-System.debug(rs);
-System.assertNotEquals(rs[0][0], rsClone[0][0]);
-*/
     }
 
     private List<List<SObject>> executeSearch(String query) {

--- a/src/classes/QueryBuilder.cls
+++ b/src/classes/QueryBuilder.cls
@@ -12,6 +12,9 @@
 */
 public abstract class QueryBuilder extends NebulaCore {
 
+    private static Map<Integer, List<SObject>> cachedQueryResultsByHashCode        = new Map<Integer, List<SObject>>();
+    private static Map<Integer, List<List<SObject>>> cachedSearchResultsByHashCode = new Map<Integer, List<List<SObject>>>();
+
     protected List<String> whereClauseList;
     protected List<String> orderByList;
     protected Integer limitCount;
@@ -19,11 +22,18 @@ public abstract class QueryBuilder extends NebulaCore {
     protected SObjectType sobjectType;
     protected Map<String, Schema.SObjectField> sobjectTypeFieldMap;
 
+    private Boolean cacheResults;
+
     public QueryBuilder() {
         this.currentModule = NebulaCore.Module.QUERY_BUILDER;
 
-        this.whereClauseList          = new List<String>();
-        this.orderByList              = new List<String>();
+        this.whereClauseList = new List<String>();
+        this.orderByList     = new List<String>();
+        this.cacheResults    = false;
+    }
+
+    protected void doCacheResults() {
+        this.cacheResults = true;
     }
 
     protected void doFilterBy(IQueryFilter queryFilter) {
@@ -83,19 +93,13 @@ public abstract class QueryBuilder extends NebulaCore {
     }
 
     protected List<SObject> doGetQueryResults(String query) {
-        List<SObject> results = Database.query(query);
-
-        this.logResults(query, results);
-
-        return results;
+        if(this.cacheResults) return this.getCachedQuery(query);
+        else return this.executeQuery(query);
     }
 
     protected List<List<SObject>> doGetSearchResults(String query) {
-        List<List<SObject>> results = Search.query(query);
-
-        this.logResults(query, results);
-
-        return results;
+        if(this.cacheResults) return this.getCachedSearch(query);
+        else return this.executeSearch(query);
     }
 
     private void filterByWithSeparator(List<IQueryFilter> queryFilters, String separator) {
@@ -106,6 +110,68 @@ public abstract class QueryBuilder extends NebulaCore {
 
         String orStatement = '(' + String.join(queryFilterValues, ' ' + separator + ' ') + ')';
         this.whereClauseList.add(orStatement);
+    }
+
+    private List<SObject> getCachedQuery(String query) {
+        Integer hashCode = query.hashCode();
+
+        Boolean isCached = cachedQueryResultsByHashCode.containsKey(hashCode);
+        if(!isCached) cachedQueryResultsByHashCode.put(hashCode, this.executeQuery(query));
+
+        // Always return a deep clone so the original cached version is never modified
+        return cachedQueryResultsByHashCode.get(hashCode).deepClone(true, true, true);
+    }
+
+    private List<SObject> executeQuery(String query) {
+        List<SObject> results = Database.query(query);
+        this.logResults(query, results);
+        return results;
+    }
+
+    private List<List<SObject>> getCachedSearch(String query) {
+        Integer hashCode = query.hashCode();
+
+        Boolean isCached = cachedSearchResultsByHashCode.containsKey(hashCode);
+        if(!isCached) cachedSearchResultsByHashCode.put(hashCode, this.executeSearch(query));
+
+        // Always return a deep clone so the original cached version is never modified
+        List<List<SObject>> cachedResults = cachedSearchResultsByHashCode.get(hashCode);
+        List<List<SObject>> deepClonedResults = new List<List<SObject>>();
+        for(List<SObject> cachedListOfResults : cachedResults) deepClonedResults.add(cachedListOfResults.deepClone(true, true, true));
+        return deepClonedResults;
+
+        /* Sample code to show cloneing the list of list (doesn't work) vs deep cloning each list withn the list of lists
+        List<List<SObject>> cachedResults = [find 'gillespie' in all fields returning account(id, name)];
+List<List<SObject>> clonedResults = new List<List<SObject>>();
+for(List<SObject> cachedListOfResults : cachedResults) clonedResults.add(cachedListOfResults.deepClone(true, true, true));
+
+System.debug(cachedResults);
+clonedResults[0][0].put('Name', 'Poop');
+clonedResults[0][0].put('Id', null);
+System.debug(clonedResults);
+System.debug(cachedResults);
+System.assertNotEquals(cachedResults[0][0], clonedResults[0][0]);
+insert clonedResults[0][0];
+System.debug(clonedResults);
+System.debug(cachedResults);
+System.assertNotEquals(cachedResults[0][0], clonedResults[0][0]);
+System.assertNotEquals(cachedResults[0][0].Id, clonedResults[0][0].Id);
+///
+
+List<List<Sobject>> rs = [find 'gillespie' in all fields returning account(id, name)];
+System.debug(rs);
+List<List<Sobject>> rsClone = rs.clone();
+rsClone[0][0].put('Name', 'Poop');
+System.debug(rsClone);
+System.debug(rs);
+System.assertNotEquals(rs[0][0], rsClone[0][0]);
+*/
+    }
+
+    private List<List<SObject>> executeSearch(String query) {
+        List<List<SObject>> results = Search.query(query);
+        this.logResults(query, results);
+        return results;
     }
 
     private void logResults(String query, List<Object> results) {

--- a/src/classes/SObjectQueryBuilder.cls
+++ b/src/classes/SObjectQueryBuilder.cls
@@ -34,6 +34,7 @@ public class SObjectQueryBuilder extends QueryBuilder implements ISObjectQueryBu
         super.doCacheResults();
         return this;
     }
+
     public ISObjectQueryBuilder addFields(List<IQueryField> queryFields) {
         for(IQueryField queryField : queryFields) this.addField(queryField);
         return this;

--- a/src/classes/SObjectQueryBuilder.cls
+++ b/src/classes/SObjectQueryBuilder.cls
@@ -30,6 +30,10 @@ public class SObjectQueryBuilder extends QueryBuilder implements ISObjectQueryBu
         this.addCommonQueryFields();
     }
 
+    public ISObjectQueryBuilder cacheResults() {
+        super.doCacheResults();
+        return this;
+    }
     public ISObjectQueryBuilder addFields(List<IQueryField> queryFields) {
         for(IQueryField queryField : queryFields) this.addField(queryField);
         return this;

--- a/src/classes/SObjectQueryBuilder_Tests.cls
+++ b/src/classes/SObjectQueryBuilder_Tests.cls
@@ -60,6 +60,35 @@ private class SObjectQueryBuilder_Tests {
     }
 
     @isTest
+    static void it_should_be_usable_after_construction() {
+        // Query builders should be usable as soon as it's constructed - it should be able to execute a query with some default values
+        ISObjectQueryBuilder opportunityQueryBuilder = new SObjectQueryBuilder(Schema.Opportunity.SObjectType);
+
+        Test.startTest();
+
+        List<Opportunity> results = (List<Opportunity>)opportunityQueryBuilder.getQueryResults();
+
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_cache_results() {
+        ISObjectQueryBuilder opportunityQueryBuilder = new SObjectQueryBuilder(Schema.Opportunity.SObjectType);
+        opportunityQueryBuilder.cacheResults();
+
+        Test.startTest();
+
+        System.assertEquals(0, Limits.getQueries());
+        for(Integer i = 0; i < 10; i++) {
+            System.debug(opportunityQueryBuilder.getQueryResults());
+        }
+
+        System.assertEquals(1, Limits.getQueries());
+
+        Test.stopTest();
+    }
+
+    @isTest
     static void it_should_add_a_list_of_fields() {
         NebulaSettings.SObjectQueryBuilderSettings.IncludeCommonFields__c = false;
         upsert NebulaSettings.SObjectQueryBuilderSettings;
@@ -378,7 +407,7 @@ private class SObjectQueryBuilder_Tests {
 
         Test.startTest();
         SObjectQueryBuilder query = (SObjectQueryBuilder)new SObjectQueryBuilder(sobjectType).addFields(convertToQueryFields(fields));
-        query.setAsUpdate();
+        query.forUpdate();
         Test.stopTest();
 
         System.assert(query.getQuery().contains('FOR UPDATE'));

--- a/src/classes/SObjectQueryBuilder_Tests.cls
+++ b/src/classes/SObjectQueryBuilder_Tests.cls
@@ -407,7 +407,7 @@ private class SObjectQueryBuilder_Tests {
 
         Test.startTest();
         SObjectQueryBuilder query = (SObjectQueryBuilder)new SObjectQueryBuilder(sobjectType).addFields(convertToQueryFields(fields));
-        query.forUpdate();
+        query.setAsUpdate();
         Test.stopTest();
 
         System.assert(query.getQuery().contains('FOR UPDATE'));

--- a/src/classes/SObjectRecordTypes.cls
+++ b/src/classes/SObjectRecordTypes.cls
@@ -12,24 +12,18 @@
 */
 public abstract class SObjectRecordTypes extends NebulaCore implements ISObjectRecordTypes {
 
-    private static Map<String, List<RecordType>> cachedRecordTypesBySObjectMap = new Map<String, List<RecordType>>();
-
     private String sobjectName;
 
     public SObjectRecordTypes() {
         this.currentModule = NebulaCore.Module.RECORD_TYPES;
 
         this.sobjectName = this.getSObjectType().getDescribe().getName();
-
-        Logger.addEntry(this, 'Getting record types for ' + this.sobjectName);
-
-        this.populateCache();
     }
 
     public abstract Schema.SObjectType getSObjectType();
 
     public Map<Id, RecordType> getAllById() {
-        return new Map<Id, RecordType>(cachedRecordTypesBySObjectMap.get(this.sobjectName));
+        return new Map<Id, RecordType>(getRecordTypes());
     }
 
     public Map<String, RecordType> getAllByDeveloperName() {
@@ -43,14 +37,9 @@ public abstract class SObjectRecordTypes extends NebulaCore implements ISObjectR
         return allRecordTypesByDeveloperName;
     }
 
-    // TODO clean up all this mess for cache, getRecordTypes, getAllRecordTypesByDeveloperName, etc
-    // Too many similarly named methods going on
-    private void populateCache() {
-        if(cachedRecordTypesBySObjectMap.containsKey(this.sobjectName)) return;
-
-        // Trying to call Schema.RecordType.SObjectType confuses Apex, so we have to get it through an extra describe call
+    private List<RecordType> getRecordTypes() {
         Schema.SObjectType recordTypeSObjectType = Schema.SObjectType.RecordType.getSObjectType();
-        ISObjectQueryBuilder query = new SObjectQueryBuilder(recordTypeSObjectType);
+        ISObjectQueryBuilder query = new SObjectQueryBuilder(recordTypeSObjectType).orderBy(new QueryField(Schema.RecordType.DeveloperName));
 
         // If we don't have the SObject cached, then we need to query
         if(NebulaSettings.RecordTypesSettings.LazyLoad__c) {
@@ -63,15 +52,9 @@ public abstract class SObjectRecordTypes extends NebulaCore implements ISObjectR
             query.filterBy(new QueryFilter().filterByField(new QueryField(Schema.RecordType.NamespacePrefix), QueryOperator.EQUALS, null));
         }
 
-        query.orderBy(new QueryField(Schema.RecordType.DeveloperName));
-
         Logger.addEntry(this, 'Loading SObjectRecordTypes for=' + this.getSObjectType());
 
-        if(!cachedRecordTypesBySObjectMap.containsKey(this.sobjectName)) cachedRecordTypesBySObjectMap.put(this.sobjectName, new List<RecordType>());
-        List<RecordType> recordTypeList = (List<RecordType>)query.getQueryResults();
-        for(RecordType recordType : recordTypeList) cachedRecordTypesBySObjectMap.get(this.sobjectName).add(recordType);
-
-        Logger.addEntry(this, 'cachedRecordTypesBySObjectMap=' + cachedRecordTypesBySObjectMap);
+        return (List<RecordType>)query.cacheResults().getQueryResults();
     }
 
 }

--- a/src/classes/SearchQueryBuilder.cls
+++ b/src/classes/SearchQueryBuilder.cls
@@ -31,6 +31,11 @@ public class SearchQueryBuilder extends QueryBuilder implements ISearchQueryBuil
         this.parseSObjectQueryBuilders();
     }
 
+    public ISearchQueryBuilder cacheResults() {
+        super.doCacheResults();
+        return this;
+    }
+
     public ISearchQueryBuilder setQuerySearchGroup(QuerySearchGroup searchGroup) {
         this.searchGroup = searchGroup;
         return this;

--- a/src/classes/SearchQueryBuilder_Tests.cls
+++ b/src/classes/SearchQueryBuilder_Tests.cls
@@ -1,0 +1,53 @@
+/*************************************************************************************************
+* This file is part of the Nebula Framework project, released under the MIT License.             *
+* See LICENSE file or go to https://github.com/jongpie/NebulaFramework for full license details. *
+*************************************************************************************************/
+@isTest
+private class SearchQueryBuilder_Tests {
+
+    @isTest
+    static void it_should_cache_results() {
+        String searchTerm = 'test';
+        ISObjectQueryBuilder opportunityQueryBuilder = new SObjectQueryBuilder(Schema.Opportunity.SObjectType);
+
+        ISearchQueryBuilder searchQueryBuilder = new SearchQueryBuilder(searchTerm, new List<ISObjectQueryBuilder>{opportunityQueryBuilder});
+        searchQueryBuilder.cacheResults();
+
+        Test.startTest();
+
+        System.assertEquals(0, Limits.getSoslQueries());
+        for(Integer i = 0; i < 10; i++) {
+            System.debug(searchQueryBuilder.getSearchResults());
+        }
+
+        System.assertEquals(1, Limits.getSoslQueries());
+
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_set_search_group() {
+        // TODO finish writing tests!
+    }
+
+    @isTest
+    static void it_should_add_sobject_query_builder() {
+        // TODO finish writing tests!
+    }
+
+    @isTest
+    static void it_should_get_query() {
+        // TODO finish writing tests!
+    }
+
+    @isTest
+    static void it_should_get_first_query_results() {
+        // TODO finish writing tests!
+    }
+
+    @isTest
+    static void it_should_get_query_results() {
+        // TODO finish writing tests!
+    }
+
+}

--- a/src/classes/SearchQueryBuilder_Tests.cls
+++ b/src/classes/SearchQueryBuilder_Tests.cls
@@ -6,6 +6,21 @@
 private class SearchQueryBuilder_Tests {
 
     @isTest
+    static void it_should_be_usable_after_construction() {
+        // Query builders should be usable as soon as it's constructed - it should be able to execute a query with some default values
+        String searchTerm = 'test';
+        ISObjectQueryBuilder opportunityQueryBuilder = new SObjectQueryBuilder(Schema.Opportunity.SObjectType);
+
+        ISearchQueryBuilder searchQueryBuilder = new SearchQueryBuilder(searchTerm, new List<ISObjectQueryBuilder>{opportunityQueryBuilder});
+
+        Test.startTest();
+
+        List<List<SObject>> results = (List<List<SObject>>)searchQueryBuilder.getSearchResults();
+
+        Test.stopTest();
+    }
+
+    @isTest
     static void it_should_cache_results() {
         String searchTerm = 'test';
         ISObjectQueryBuilder opportunityQueryBuilder = new SObjectQueryBuilder(Schema.Opportunity.SObjectType);

--- a/src/classes/SearchQueryBuilder_Tests.cls-meta.xml
+++ b/src/classes/SearchQueryBuilder_Tests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Fixes #41 

There are situations where it's useful to cache queries so that the query is executed once in the current transaction. For example, Nebula caches the query for record types in SObjectRecordTypes.cls. However, the caching used is very specific to that class/query. Now that all query builders leverage QueryBuilder.cls, 

I've updated QueryBuilder.cls to allow queries to be cached by simply calling cacheResults(). 

- **Storing the cached results**: cacheResults() stores the query's hash code & the query results in a map - the cached values are returned from the map instead of executing the query again. The cache only lives in memory, so it only lasts for the extent of a transaction
- **Consistent query hash codes**: In preparation for this change, I've been incorporating changes to the query builders, like sorting the list of query fields, query filters and order by clause - because the query parts are sorted (when possible) and Nebula generates the queries, the generated query should be consistent, even if the calls to the query builder methods are in a different order. This means that if 2 different query builders generate the same query and both are cached, then only 1 query is executed

```
// First query builder uses the addAllFields() method
ISObjectQueryBuilder query1 = new SObjectQueryBuilder(Schema.Account.SObjectType).addAllFields();

// First query builder uses the addAllStandardFields() and addAllCustomFields() methods - the result is the same as using addAllFields()
ISObjectQueryBuilder query2 = new SObjectQueryBuilder(Schema.Account.SObjectType).addAllStandardFields().addAllCustomFields();

// Verify that the hash codes match, even though different steps were taken to generate each query
System.assertEquals(query1.getQuery().hashCode(), query2.getQuery().hashCode());
```