### PR TITLE
Added support for OFFSET, FOR VIEW & FOR REFERENCE

### DIFF
--- a/src/classes/ISObjectQueryBuilder.cls
+++ b/src/classes/ISObjectQueryBuilder.cls
@@ -35,7 +35,10 @@ public interface ISObjectQueryBuilder {
 
     // Additional query option methods
     ISObjectQueryBuilder limitCount(Integer limitCount);
-    ISObjectQueryBuilder setAsUpdate();
+    ISObjectQueryBuilder offset(Integer numberOfRowsToSkip);
+    ISObjectQueryBuilder forReference();
+    ISObjectQueryBuilder forUpdate();
+    ISObjectQueryBuilder forView();
     ISObjectQueryBuilder usingScope(QueryFilterScope filterScope);
 
     // Query string methods

--- a/src/classes/SObjectQueryBuilder.cls
+++ b/src/classes/SObjectQueryBuilder.cls
@@ -15,7 +15,10 @@ public class SObjectQueryBuilder extends QueryBuilder implements ISObjectQueryBu
     private Set<String> queryFields;
     private List<String> childRelationshipQueries;
     private QueryFilterScope filterScope;
+    private Integer offset;
+    private Boolean forReference;
     private Boolean forUpdate;
+    private Boolean forView;
     private SObjectType sobjectType;
     private Map<String, Schema.SObjectField> sobjectTypeFieldMap;
 
@@ -25,7 +28,9 @@ public class SObjectQueryBuilder extends QueryBuilder implements ISObjectQueryBu
 
         this.queryFields              = new Set<String>();
         this.childRelationshipQueries = new List<String>();
+        this.forReference             = false;
         this.forUpdate                = false;
+        this.forView                = false;
 
         this.addCommonQueryFields();
     }
@@ -118,8 +123,23 @@ public class SObjectQueryBuilder extends QueryBuilder implements ISObjectQueryBu
         return this;
     }
 
-    public ISObjectQueryBuilder setAsUpdate() {
+    public ISObjectQueryBuilder offset(Integer numberOfRowsToSkip) {
+        this.offset = numberOfRowsToSkip;
+        return this;
+    }
+
+    public ISObjectQueryBuilder forReference() {
+        this.forReference = true;
+        return this;
+    }
+
+    public ISObjectQueryBuilder forUpdate() {
         this.forUpdate = true;
+        return this;
+    }
+
+    public ISObjectQueryBuilder forView() {
+        this.forView = true;
         return this;
     }
 

--- a/src/classes/SObjectQueryBuilder_Tests.cls
+++ b/src/classes/SObjectQueryBuilder_Tests.cls
@@ -378,7 +378,7 @@ private class SObjectQueryBuilder_Tests {
 
         Test.startTest();
         SObjectQueryBuilder query = (SObjectQueryBuilder)new SObjectQueryBuilder(sobjectType).addFields(convertToQueryFields(fields));
-        query.setAsUpdate();
+        query.forUpdate();
         Test.stopTest();
 
         System.assert(query.getQuery().contains('FOR UPDATE'));


### PR DESCRIPTION
Fixes #8 

ISObjectRepository has 3 new methods, plus 1 renamed method
- New: ISObjectQueryBuilder offset(Integer numberOfRowsToSkip);
- New: ISObjectQueryBuilder forReference();
- Renamed: ISObjectQueryBuilder forUpdate(); - formally called setAsUpdate();
- New: ISObjectQueryBuilder forView();